### PR TITLE
Improve VNC performance and container output/logging

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,8 +6,8 @@ WORKDIR /etc/guacamole
 RUN apt-get update &&            \
     apt-get install -y           \
       software-properties-common \
-      libjpeg62                  \
-      libjpeg62-dev              \
+      libjpeg-turbo8             \
+      libjpeg-turbo8-dev         \
       libcairo2-dev              \
       libossp-uuid-dev           \
       libpng-dev                 \
@@ -36,7 +36,6 @@ RUN apt-get update &&  \
       firefox          \
       gcc              \
       gcc-6            \
-      libvncserver-dev \
       make             \
       openssh-server   \
       sudo             \
@@ -47,10 +46,14 @@ RUN apt-get update &&  \
       xfce4-goodies && \
     rm -rf /var/lib/apt/lists/*
 
+RUN DEBIAN_FRONTEND=noninteractive apt-get update && apt-get install -y gtk2.0 && rm -rf /var/lib/apt/lists/*
+RUN wget "https://github.com/LibVNC/libvncserver/archive/LibVNCServer-0.9.9.tar.gz" && \
+    tar xvf LibVNCServer-0.9.9.tar.gz &&    \
+    cd libvncserver-LibVNCServer-0.9.9 &&   \
+    ./autogen.sh && make && make install && \
+    cd .. && rm -r libvncserver-LibVNCServer-0.9.9 LibVNCServer-0.9.9.tar.gz
+
 # Install TigerVNC server
-#RUN wget "https://bintray.com/tigervnc/stable/download_file?file_path=ubuntu-16.04LTS%2Famd64%2Ftigervncserver_1.8.0-1ubuntu1_amd64.deb" -O /root/tigervnc.deb && \
-#    dpkg -i /root/tigervnc.deb && \
-#    rm /root/tigervnc.deb
 RUN wget "https://bintray.com/tigervnc/stable/download_file?file_path=tigervnc-1.9.0.x86_64.tar.gz" -O /root/tigervnc.tar.gz && \
     tar -C / --strip-components=1 --show-transformed-names -xvzf /root/tigervnc.tar.gz && \
     rm /root/tigervnc.tar.gz
@@ -64,7 +67,7 @@ RUN tar xvf /etc/guacamole/guacamole-server-0.9.14.tar.gz
 # Install guacd
 WORKDIR /etc/guacamole/guacamole-server-0.9.14
 RUN ./configure --with-init-dir=/etc/init.d && \
-    make CC=gcc-6 &&                                    \
+    make CC=gcc-6 &&                           \
     make install &&                            \
     ldconfig &&                                \
     rm -r /etc/guacamole/guacamole-server-0.9.14*

--- a/Dockerfile
+++ b/Dockerfile
@@ -33,7 +33,7 @@ ENV LC_ALL en_US.UTF-8
 RUN apt-get update &&  \
     DEBIAN_FRONTEND=noninteractive apt-get install -y \
       bash-completion  \
-      firefox          \
+      chromium-browser \
       gcc              \
       gcc-6            \
       make             \
@@ -87,6 +87,9 @@ RUN /usr/bin/printf '%s\n%s\n%s\n' 'password' 'password' 'n' | su user -c vncpas
 
 # Remove keyboard shortcut to allow bash_completion in xfce4-terminal
 RUN echo "DISPLAY=:1 xfconf-query -c xfce4-keyboard-shortcuts -p \"/xfwm4/custom/<Super>Tab\" -r" >> /home/user/.bashrc
+
+# Fix chromium-browser to run with no sandbox
+RUN sed -i -e 's/Exec=chromium-browser/Exec=chromium-browser --no-sandbox/g' /usr/share/applications/chromium-browser.desktop
 
 # Add help message
 RUN touch /etc/help-msg

--- a/startup.sh
+++ b/startup.sh
@@ -97,9 +97,8 @@ else
   default
 fi
 
-service guacd start && \
 service ssh start &&   \
 service tomcat8 start; \
 su user -c "USER=user vncserver -depth 24 -geometry $RES -name \"VNC\" :1" && \
 cat /etc/help-msg && \
-tail -f /dev/null
+guacd -L debug -f


### PR DESCRIPTION
This PR prevents (or at least reduces) VNC disconnects by installing libvncserver` 0.9.9 from source instead of 0.9.11 provided by Ubuntu as mentioned in [GUACAMOLE-414](https://issues.apache.org/jira/projects/GUACAMOLE/issues/GUACAMOLE-414).

Also install `libjpeg-turbo` to improve performance.

Changed the startup script so the container will output guacd logs which aids in debugging and is better than outputting nothing at all since this is run in the background.

Also installed chromium-browser